### PR TITLE
Added ability to disable redraw requests when adding/removing layers.

### DIFF
--- a/src/QWidgetMap/LayerManager.cpp
+++ b/src/QWidgetMap/LayerManager.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Layer> LayerManager::layer(const std::string& name) const
     return return_layer;
 }
 
-void LayerManager::add(const std::shared_ptr<Layer>& layer, const int& index)
+void LayerManager::add(const std::shared_ptr<Layer>& layer, const int& index, const bool& disable_redraw)
 {
     // Check we have a valid layer.
     if(layer != nullptr)
@@ -87,12 +87,19 @@ void LayerManager::add(const std::shared_ptr<Layer>& layer, const int& index)
             }
         }
 
+        // Should we redraw?
+        if(disable_redraw == false)
+        {
+            // Emit that the layer has changed.
+            emit layerChanged();
+        }
+
         // Emit that the layer has been added.
         emit layerAdded(layer);
     }
 }
 
-void LayerManager::remove(const std::string& name)
+void LayerManager::remove(const std::string& name, const bool& disable_redraw)
 {
     // Fetch the layer by name.
     const auto layer_to_remove(layer(name));
@@ -115,6 +122,13 @@ void LayerManager::remove(const std::string& name)
                 // Remove the layer.
                 m_layers.erase(itr_find);
             }
+        }
+
+        // Should we redraw?
+        if(disable_redraw == false)
+        {
+            // Emit that the layer has changed.
+            emit layerChanged();
         }
 
         // Emit that the layer has been removed.

--- a/src/QWidgetMap/LayerManager.h
+++ b/src/QWidgetMap/LayerManager.h
@@ -78,15 +78,17 @@ namespace qwm
          * If multiple layers are added, they are painted in the added order (the last added wil be the top layer).
          * @param layer The layer which should be added.
          * @param index The index position the layer should added (-1 means the layer is added to the top).
+         * @param disable_redraw Whether to disable the redraw call after the layer has been added (allows bulk adding without redrawing each time).
          * @note 'index 0' is the base layer, 'index 1 layer' will be painted on top of 'index 0 layer', and so on...
          */
-        void add(const std::shared_ptr<Layer>& layer, const int& index = -1);
+        void add(const std::shared_ptr<Layer>& layer, const int& index = -1, const bool& disable_redraw = false);
 
         /**
          * Removes a layer.
          * @param name The name of the layer which should be removed.
+         * @param disable_redraw Whether to disable the redraw call after the layer has been removed (allows bulk removal without redrawing each time).
          */
-        void remove(const std::string& name);
+        void remove(const std::string& name, const bool& disable_redraw = false);
 
     signals:
 

--- a/src/QWidgetMap/RenderManager.cpp
+++ b/src/QWidgetMap/RenderManager.cpp
@@ -37,9 +37,7 @@ RenderManager::RenderManager(const std::shared_ptr<ViewportManager>& viewport_ma
     qRegisterMetaType<util::RectWorldCoord>("util::RectWorldCoord");
 
     // Connect signal/slots to process changes that require a redraw request.
-    QObject::connect(m_layer_manager.get(), &LayerManager::layerAdded, this, &RenderManager::requestRedraw);
     QObject::connect(m_layer_manager.get(), &LayerManager::layerChanged, this, &RenderManager::requestRedraw);
-    QObject::connect(m_layer_manager.get(), &LayerManager::layerRemoved, this, &RenderManager::requestRedraw);
     QObject::connect(&(util::ImageManager::get()), &util::ImageManager::imageUpdated, this, &RenderManager::requestRedraw);
 
     // Start the render thread.


### PR DESCRIPTION
This allows bulk adding/removing of layers without staging multiple redraw requests.

To force a redraw after the bulk operation, emit the layerChanged() signal.
