### PR TITLE
Fixes #4 by adding a Qt Version check for the required include.

### DIFF
--- a/src/QtDesignerPlugins/PluginQProgressIndicator/PluginQProgressIndicator.h
+++ b/src/QtDesignerPlugins/PluginQProgressIndicator/PluginQProgressIndicator.h
@@ -18,7 +18,12 @@
 #pragma once
 
 // Qt includes.
+#include <QtCore/QtGlobal>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
 #include <QtDesigner/QDesignerCustomWidgetInterface>
+#else
+#include <QtUiPlugin/QDesignerCustomWidgetInterface>
+#endif
 
 class PluginQProgressIndicator : public QObject, public QDesignerCustomWidgetInterface
 {

--- a/src/QtDesignerPlugins/PluginQWidgetMap/PluginQWidgetMap.h
+++ b/src/QtDesignerPlugins/PluginQWidgetMap/PluginQWidgetMap.h
@@ -18,7 +18,12 @@
 #pragma once
 
 // Qt includes.
+#include <QtCore/QtGlobal>
+#if (QT_VERSION < QT_VERSION_CHECK(5, 5, 0))
 #include <QtDesigner/QDesignerCustomWidgetInterface>
+#else
+#include <QtUiPlugin/QDesignerCustomWidgetInterface>
+#endif
 
 class PluginQWidgetMap : public QObject, public QDesignerCustomWidgetInterface
 {


### PR DESCRIPTION
Qt 5.5 moved the QDesignerCustomWidgetInterface header from QtDesigner to QtUiPlugin.

This pull request adds a version check where required to handle this change.
