### PR TITLE
Fixes #6

### DIFF
--- a/src/QWidgetMap/Layer.cpp
+++ b/src/QWidgetMap/Layer.cpp
@@ -199,10 +199,7 @@ bool Layer::addDrawable(const std::shared_ptr<draw::Drawable>& drawable, const b
                 QWriteLocker locker(&m_drawable_geometries_mutex);
 
                 // Add the geometry point container.
-                m_drawable_geometries_points.insert(std::static_pointer_cast<draw::geometry::GeometryPoint>(drawable_geometry)->coord(), drawable_geometry);
-
-                // Update our success.
-                success = true;
+                success = m_drawable_geometries_points.insert(std::static_pointer_cast<draw::geometry::GeometryPoint>(drawable_geometry)->coord(), drawable_geometry);
             }
             else
             {

--- a/src/QWidgetMap/util/QuadtreeContainer.h
+++ b/src/QWidgetMap/util/QuadtreeContainer.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+// Qt includes.
+#include <QtCore/QDebug>
+
 // STD includes.
 #include <cstddef>
 #include <memory>
@@ -158,8 +161,8 @@ namespace qwm
                         }
                         else
                         {
-                            // We cannot insert, fail!
-                            throw std::runtime_error("Unable to insert into quadtree container.");
+                            // Warn that we are unable to insert point into quadtree container.
+                            qDebug() << "Unable to insert point into quadtree container.";
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #6 by removing exception being thrown in QuadtreeContainer::insert. This function will now return false on failure.

Modified Layer::addDrawable to return correct success state from QuadtreeContainer::insert call.
